### PR TITLE
Improve interface for loading and writing mapping files 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ src/main/resources/data/
 src/main/resources/maven/
 src/main/resources/version.json
 src/main/resources/install_profile.json
+.idea

--- a/src/main/java/net/minecraftforge/srgutils/IMappingFile.java
+++ b/src/main/java/net/minecraftforge/srgutils/IMappingFile.java
@@ -123,7 +123,9 @@ public interface IMappingFile {
 
     default void write(Path path, Format format, boolean reversed) throws IOException {
         List<String> lines = write(format, reversed);
-        Files.createDirectories(path.getParent());
+        if (path.getParent() != null) {
+            Files.createDirectories(path.getParent());
+        }
         try (BufferedWriter writer = Files.newBufferedWriter(path)) {
             for (String line : lines) {
                 writer.write(line);

--- a/src/main/java/net/minecraftforge/srgutils/INamedMappingFile.java
+++ b/src/main/java/net/minecraftforge/srgutils/INamedMappingFile.java
@@ -75,7 +75,9 @@ public interface INamedMappingFile {
 
     default void write(Path path, Format format, String... order) throws IOException {
         List<String> lines = write(format, order);
-        Files.createDirectories(path.getParent());
+        if (path.getParent() != null) {
+            Files.createDirectories(path.getParent());
+        }
         try (BufferedWriter writer = Files.newBufferedWriter(path)) {
             for (String line : lines) {
                 writer.write(line);

--- a/src/main/java/net/minecraftforge/srgutils/InternalUtils.java
+++ b/src/main/java/net/minecraftforge/srgutils/InternalUtils.java
@@ -19,11 +19,7 @@
 
 package net.minecraftforge.srgutils;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,17 +34,12 @@ import java.util.stream.Collectors;
 import net.minecraftforge.srgutils.IMappingFile.Format;
 
 class InternalUtils {
-    static IMappingFile load(InputStream in) throws IOException {
-        INamedMappingFile named = loadNamed(in);
+    static IMappingFile load(List<String> lines) throws IOException {
+        INamedMappingFile named = loadNamed(lines);
         return named.getMap(named.getNames().get(0), named.getNames().get(1));
     }
 
-    static INamedMappingFile loadNamed(InputStream in) throws IOException {
-        List<String> lines = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8)).lines()
-            //.map(InternalUtils::stripComment)
-            .filter(l -> !l.isEmpty()) //Remove Empty lines
-            .collect(Collectors.toList());
-
+    static INamedMappingFile loadNamed(List<String> lines) throws IOException {
 
         String firstLine = lines.get(0);
         Iterator<String> itr = lines.iterator();

--- a/src/main/java/net/minecraftforge/srgutils/MappingFile.java
+++ b/src/main/java/net/minecraftforge/srgutils/MappingFile.java
@@ -126,7 +126,7 @@ class MappingFile implements IMappingFile {
     }
 
     @Override
-    public void write(Path path, Format format, boolean reversed) throws IOException {
+    public List<String> write(Format format, boolean reversed) {
         List<String> lines = new ArrayList<>();
         Comparator<INode> sort = reversed ? (a,b) -> a.getMapped().compareTo(b.getMapped()) : (a,b) -> a.getOriginal().compareTo(b.getOriginal());
 
@@ -169,13 +169,7 @@ class MappingFile implements IMappingFile {
             lines.add(0, "tsrg2 left right");
         }
 
-        Files.createDirectories(path.getParent());
-        try (BufferedWriter writer = Files.newBufferedWriter(path)) {
-            for (String line : lines) {
-                writer.write(line);
-                writer.write('\n');
-            }
-        }
+        return lines;
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/srgutils/NamedMappingFile.java
+++ b/src/main/java/net/minecraftforge/srgutils/NamedMappingFile.java
@@ -78,7 +78,7 @@ class NamedMappingFile implements INamedMappingFile, IMappingBuilder {
     }
 
     @Override
-    public void write(Path path, Format format, String... order) throws IOException {
+    public List<String> write(Format format, String... order) {
         if (order == null || order.length == 1)
             throw new IllegalArgumentException("Invalid order, you must specify atleast 2 names");
 
@@ -141,13 +141,7 @@ class NamedMappingFile implements INamedMappingFile, IMappingBuilder {
             lines.add(0, buf.toString());
         }
 
-        Files.createDirectories(path.getParent());
-        try (BufferedWriter writer = Files.newBufferedWriter(path)) {
-            for (String line : lines) {
-                writer.write(line);
-                writer.write('\n');
-            }
-        }
+        return lines;
     }
 
     // Internal Utilities


### PR DESCRIPTION
This PR improves the way that `IMappingFile`s and `INamedMappingFile`s are loaded and saved.

Instead of being limited to reading from a `File` or `InputStream` and writing to a `Path`, the loading and writing interfaces are now expanded. `I(Named)MappingFile`s, in addition to being readable from `File`s and `InputStream`s (to maintain binary compatibility), can now be read from a `Path` or `Reader`, as well as from a raw `List<String>` (helpful for manipulating mapping files in memory).

`I(Named)MappingFile` now write to a `List<String>` instead of directly to a `Path`, which is helpful for passing mapping data in memory without need to write to then read from disk. The method of writing to a `Path` is kept in, both because it is useful and to remain binary compatibility.

Also fixed a bug when writing to a `Path` with no parent directory (which is possible when using an in-memory `FileSystem` like [Jimfs](https://github.com/google/jimfs)) would cause a `NullPointerException` due to the `Files.createDirectories` call.