### PR TITLE
Add filtering and filling capability to MappingFile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     testImplementation('org.junit.jupiter:junit-jupiter:5.7.0')
     testImplementation('org.junit.jupiter:junit-jupiter-engine:5.7.0')
     testImplementation('org.powermock:powermock-core:2.0.9')
+    testImplementation 'com.google.jimfs:jimfs:1.1'
     compileOnly('com.google.code.findbugs:jsr305:3.0.2')
 }
 

--- a/src/main/java/net/minecraftforge/srgutils/CompleteRenamer.java
+++ b/src/main/java/net/minecraftforge/srgutils/CompleteRenamer.java
@@ -1,0 +1,73 @@
+/*
+ * SRG Utils
+ * Copyright (c) 2021
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.srgutils;
+
+import net.minecraftforge.srgutils.IMappingFile.IClass;
+import net.minecraftforge.srgutils.IMappingFile.IField;
+import net.minecraftforge.srgutils.IMappingFile.IMethod;
+import net.minecraftforge.srgutils.IMappingFile.IPackage;
+import net.minecraftforge.srgutils.IMappingFile.IParameter;
+
+/**
+ * Implementation of {@link IRenamer} used to rename all types of nodes in mapping
+ */
+public class CompleteRenamer implements IRenamer
+{
+
+    public CompleteRenamer(IMappingFile reference) {
+        this.reference = reference;
+    }
+
+    private final IMappingFile reference;
+
+    @Override
+    public String rename(IPackage value) {
+        IPackage pkg = reference.getPackage(value.getOriginal());
+        return pkg == null ? value.getMapped() : pkg.getMapped();
+    }
+
+    @Override
+    public String rename(IClass value) {
+        IClass cls = reference.getClass(value.getOriginal());
+        return cls == null ? value.getMapped() : cls.getMapped();
+    }
+
+    @Override
+    public String rename(IField value) {
+        IClass cls = reference.getClass(value.getParent().getOriginal());
+        IField fld = cls == null ? null : cls.getField(value.getOriginal());
+        return fld == null ? value.getMapped() : fld.getMapped();
+    }
+
+    @Override
+    public String rename(IMethod value) {
+        IClass cls = reference.getClass(value.getParent().getOriginal());
+        IMethod mtd = cls == null ? null : cls.getMethod(value.getOriginal(), value.getDescriptor());
+        return mtd == null ? value.getMapped() : mtd.getMapped();
+    }
+
+    @Override
+    public String rename(IParameter value) {
+        IMethod mtd = value.getParent();
+        IClass cls = reference.getClass(mtd.getParent().getOriginal());
+        mtd = cls == null ? null : cls.getMethod(mtd.getOriginal(), mtd.getDescriptor());
+        return mtd == null ? value.getMapped() : mtd.remapParameter(value.getIndex(), value.getMapped());
+    }
+}

--- a/src/main/java/net/minecraftforge/srgutils/IMappingFile.java
+++ b/src/main/java/net/minecraftforge/srgutils/IMappingFile.java
@@ -96,6 +96,15 @@ public interface IMappingFile {
     void write(Path path, Format format, boolean reversed) throws IOException;
 
     IMappingFile reverse();
+
+    /**
+     * Filters mapping nodes that has equal original and mapped name.
+     * 
+     * <p>Classes and methods are removed only if children nodes can be filtered too.
+     * 
+     * @return filtered mapping without nodes with equal names
+     */
+    IMappingFile filter();
     IMappingFile rename(IRenamer renamer);
     IMappingFile chain(IMappingFile other);
 
@@ -119,6 +128,13 @@ public interface IMappingFile {
          *     "end_line": The source line for the end of this method
          */
         Map<String, String> getMetadata();
+
+        /**
+         * Determines if node can be filtered from mapping.
+         * 
+         * @return {@code true} when node can be filtered
+         */
+        boolean canBeFiltered();
     }
 
     public interface IPackage extends INode {}

--- a/src/main/java/net/minecraftforge/srgutils/IMappingFile.java
+++ b/src/main/java/net/minecraftforge/srgutils/IMappingFile.java
@@ -108,6 +108,16 @@ public interface IMappingFile {
     IMappingFile rename(IRenamer renamer);
     IMappingFile chain(IMappingFile other);
 
+    /**
+     * Fills mapping with nodes from another mapping.
+     * 
+     * <p>Both mapping must have common original side to resolve node linkage.
+     * 
+     * @param other mapping to fill with nodes
+     * @return mapping filled with missing nodes
+     */
+    IMappingFile fill(IMappingFile other);
+
     public interface INode {
         String getOriginal();
         String getMapped();

--- a/src/test/java/net/minecraftforge/srgutils/test/OperationsTest.java
+++ b/src/test/java/net/minecraftforge/srgutils/test/OperationsTest.java
@@ -1,0 +1,90 @@
+/*
+ * SRG Utils
+ * Copyright (c) 2021
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.srgutils.test;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import net.minecraftforge.srgutils.CompleteRenamer;
+import net.minecraftforge.srgutils.IMappingFile;
+import net.minecraftforge.srgutils.IMappingFile.Format;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class OperationsTest
+{
+
+    Path root = getRoot().resolve("Operations/");
+    IMappingFile srgA, srgB;
+    static FileSystem imfs = Jimfs.newFileSystem(Configuration.unix());
+
+    private Path getRoot() {
+        URL url = this.getClass().getResource("/test.marker");
+        Assertions.assertNotNull(url, "Could not find test.marker");
+        try {
+            return new File(url.toURI()).getParentFile().toPath();
+        } catch (URISyntaxException e) {
+            return new File(url.getPath()).getParentFile().toPath();
+        }
+    }
+
+    @BeforeEach
+    public void init() throws IOException {
+        this.srgA = IMappingFile.load(Files.newInputStream(root.resolve("input/A.txt")));
+        this.srgB = IMappingFile.load(Files.newInputStream(root.resolve("input/B.txt")));
+    }
+
+    @Test
+    public void testRename() throws IOException {
+        test(srgA.rename(new CompleteRenamer(srgB)), imfs.getPath("./out.txt"), Format.TSRG2, root.resolve("pattern/rename.txt"));
+    }
+
+    @Test
+    public void testFill() throws IOException {
+        test(srgA.fill(srgB), imfs.getPath("./out.txt"), Format.TSRG2, root.resolve("pattern/fill.txt"));
+    }
+
+    @AfterAll
+    public static void exit() throws IOException {
+        imfs.close();
+    }
+
+    private void test(IMappingFile result, Path dest, Format format, Path pattern) throws IOException {
+        result.write(dest, format, false);
+        Assertions.assertEquals(getFileContents(pattern), getFileContents(dest), "Pattern differ: " + pattern.getFileName());
+    }
+
+    private String getFileContents(Path file) {
+        try {
+            return new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read " + file.toAbsolutePath(), e);
+        }
+    }
+}

--- a/src/test/resources/Operations/input/A.txt
+++ b/src/test/resources/Operations/input/A.txt
@@ -1,0 +1,12 @@
+tsrg2 shared mappedA
+cls classA
+	fld fieldA
+	fld2 field2A
+	mtd (Lcls;ZZ)I methodA
+		1 leftA1 parameterA
+		3 leftA3 onlyA3
+		4 leftA4 onlyA4
+	mtd2 (II)D method2A
+		1 leftA1 firstA
+		2 leftA2 secondA
+cls2 classA2

--- a/src/test/resources/Operations/input/B.txt
+++ b/src/test/resources/Operations/input/B.txt
@@ -1,0 +1,11 @@
+tsrg2 shared mappedB
+cls classB
+	fld fieldB
+	fld3 I field3B
+	mtd (Lcls;ZZ)I methodB
+		1 leftB1 parameterB
+		2 leftB2 onlyB
+	mtd3 ([DII)V method3B
+		1 leftB1 firstB
+		2 leftB2 secondB
+cls3 classB2

--- a/src/test/resources/Operations/pattern/fill.txt
+++ b/src/test/resources/Operations/pattern/fill.txt
@@ -1,0 +1,18 @@
+tsrg2 left right
+cls classA
+	fld fieldA
+	fld2 field2A
+	fld3 I field3B
+	mtd (Lcls;ZZ)I methodA
+		1 leftA1 parameterA
+		2 leftB2 onlyB
+		3 leftA3 onlyA3
+		4 leftA4 onlyA4
+	mtd2 (II)D method2A
+		1 leftA1 firstA
+		2 leftA2 secondA
+	mtd3 ([DII)V method3B
+		1 leftB1 firstB
+		2 leftB2 secondB
+cls2 classA2
+cls3 classB2

--- a/src/test/resources/Operations/pattern/rename.txt
+++ b/src/test/resources/Operations/pattern/rename.txt
@@ -1,0 +1,12 @@
+tsrg2 left right
+cls classB
+	fld fieldB
+	fld2 field2A
+	mtd (Lcls;ZZ)I methodB
+		1 leftA1 parameterB
+		3 leftA3 onlyA3
+		4 leftA4 onlyA4
+	mtd2 (II)D method2A
+		1 leftA1 firstA
+		2 leftA2 secondA
+cls2 classA2


### PR DESCRIPTION
Filtering allows to remove nodes with same original and mapped side from mapping.
Filtering checks if node can be removed from mapping without interrupting rest of mapping. Fields and parameters can be always filtered because they can't have children. For classes and methods, they are tested if all children (if present) can be filtered too.

Filling is useful especially when chaining two srgs and base mapping does not cover all of nodes from second - eg. like Bukkit and official Mojang mappings. This is due to the way the mappings are chained - iterations are only performed on the base mapping nodes.
After chaining Bukkit to Mojang it can be filled with rest of Mojang nodes. That produces full mapping to convert whole Bukkit project to official names.