### PR TITLE
Use ConcurrentHashMap for the caches

### DIFF
--- a/src/main/java/net/minecraftforge/srgutils/MappingFile.java
+++ b/src/main/java/net/minecraftforge/srgutils/MappingFile.java
@@ -30,6 +30,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -43,7 +44,7 @@ class MappingFile implements IMappingFile {
     private Collection<Package> packagesView = Collections.unmodifiableCollection(packages.values());
     private Map<String, Cls> classes = new HashMap<>();
     private Collection<Cls> classesView = Collections.unmodifiableCollection(classes.values());
-    private Map<String, String> cache = new HashMap<>();
+    private Map<String, String> cache = new ConcurrentHashMap<>();
     static final Pattern DESC = Pattern.compile("L(?<cls>[^;]+);");
 
     MappingFile(){}

--- a/src/main/java/net/minecraftforge/srgutils/NamedMappingFile.java
+++ b/src/main/java/net/minecraftforge/srgutils/NamedMappingFile.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.stream.Stream;
 
@@ -46,8 +47,8 @@ class NamedMappingFile implements INamedMappingFile, IMappingBuilder {
     private final List<String> names;
     private Map<String, Package> packages = new HashMap<>();
     private Map<String, Cls> classes = new HashMap<>();
-    private Map<String, String[]> classCache = new HashMap<>();
-    private Map<String, IMappingFile> mapCache = new HashMap<>(); //TODO: Weak?
+    private Map<String, String[]> classCache = new ConcurrentHashMap<>();
+    private Map<String, IMappingFile> mapCache = new ConcurrentHashMap<>(); //TODO: Weak?
 
     NamedMappingFile(String... names) {
         if (names == null || names.length < 2)


### PR DESCRIPTION
These maps are referenced across threads in other places, so the methods should be thread-safe.

This fixes an error in FG where the cache in `MappedFile` is accessed asynchronously, resulting in the following exception:
```
Caused by: java.lang.ClassCastException: class java.util.HashMap$Node cannot be cast to class java.util.HashMap$TreeNode (java.util.HashMap$Node and java.util.HashMap$TreeNode are in module java.base of loader 'bootstrap')
```