### PR TITLE
Improve the IMappingFile.chain() method

### DIFF
--- a/src/main/java/net/minecraftforge/srgutils/IMappingFile.java
+++ b/src/main/java/net/minecraftforge/srgutils/IMappingFile.java
@@ -97,6 +97,16 @@ public interface IMappingFile {
 
     IMappingFile reverse();
     IMappingFile rename(IRenamer renamer);
+
+    /**
+     * Chain this mapping file with another.
+     * The merge strategy used for chaining is as follows:
+     * <p>
+     * A->B ("ours") and B->C ("theirs") becomes A->C. Mappings present in only ours are preserved,
+     * but mappings present only in theirs are dropped, except for parameters, which are preserved for all method mappings
+     * that were present in ours.
+     * Conflicts in metadata are resolved by overwriting with the B->C metadata.
+     */
     IMappingFile chain(IMappingFile other);
 
     public interface INode {


### PR DESCRIPTION
This new method has a clearly defined merge strategy, and properly preserves parameters and metadata.

This is needed for VanillaGradle, where Yarn, Parchment, and Quilt Mappings all have metadata and parameters, and VG uses the chain function to avoid remapping multiple times.

Also, the code is a little ugly (and based on the public API because it was prototyped outside of SRGUtils), but my brain is too fried to figure out a better way to structure it--if you have any ideas, please let me know.