### PR TITLE
Fix Tiny v1 issues

### DIFF
--- a/src/main/java/net/minecraftforge/srgutils/InternalUtils.java
+++ b/src/main/java/net/minecraftforge/srgutils/InternalUtils.java
@@ -365,6 +365,9 @@ class InternalUtils {
 
         for (int x = 1; x < lines.size(); x++) {
             String[] line = lines.get(x).split("\t");
+            if (line[0].startsWith("#")) { // Comment
+                continue;
+            }
             switch (line[0]) {
                 case "CLASS": // CLASS Name1 Name2 Name3...
                     if (line.length != nameCount + 1)

--- a/src/main/java/net/minecraftforge/srgutils/NamedMappingFile.java
+++ b/src/main/java/net/minecraftforge/srgutils/NamedMappingFile.java
@@ -382,7 +382,7 @@ class NamedMappingFile implements INamedMappingFile, IMappingBuilder {
                     case TSRG:  return '\t' + getName(order[0]) + ' ' + getName(order[1]);
                     case TSRG2: return getTsrg2(order);
                     case PG:    return "    " + InternalUtils.toSource(getDescriptor(order[0])) + ' ' + getName(order[0]) + " -> " + getName(order[1]);
-                    case TINY1: return "FIELD" + getNames(order);
+                    case TINY1: return "FIELD\t" + Cls.this.getName(order[0]) + '\t' + getDescriptor(order[0]) + getNames(order);
                     case TINY:  return "\tf\t" + getDescriptor(order[0]) + getNames(order);
                     default: throw new UnsupportedOperationException("Unknown format: " + format);
                 }


### PR DESCRIPTION
I fixed two issues which I found while using SrgUtils with Tiny v1:

- Older Tiny v1 intermediary Fabric mappings contain some lines starting with a # that contain info about the class, method and field amount in the mapping file. It would be great to be able to read those files too, so I just ignored all lines that start with a #.
- In the NamedMappingFile, the Tiny v1 fields are written in a wrong format, although the correct format is used in MappingFile. I changed this in NamedMappingFile.