### PR TITLE
fix: Address snapshot parsing in new versioning system

### DIFF
--- a/src/main/java/net/minecraftforge/srgutils/MinecraftVersion.java
+++ b/src/main/java/net/minecraftforge/srgutils/MinecraftVersion.java
@@ -153,8 +153,8 @@ public class MinecraftVersion implements Comparable<MinecraftVersion> {
             // The new versioning system https://www.minecraft.net/en-us/article/minecraft-new-version-numbering-system
             // They did not specify pre-release or release candidate naming system.
             if (version.contains("-snapshot-")) {
-                String[] pts = version.split("-snapshot-");
-                return new MinecraftVersion(Type.SNAPSHOT, version, Integer.parseInt(pts[1]), -1, 0, null, splitDots(pts[0]));
+                String[] pts = version.split("-snapshot-", 2);
+                return new MinecraftVersion(Type.SNAPSHOT, version, Integer.parseInt(pts[1]), -1, 0, "", splitDots(pts[0]));
             } else if (version.contains("-pre-")) { // New Numbering system pre-releases have {version}-pre-{number}
                 String[] pts = version.split("-pre-");
                 pre = Integer.parseInt(pts[1]);

--- a/src/test/java/net/minecraftforge/srgutils/test/VersionList.java
+++ b/src/test/java/net/minecraftforge/srgutils/test/VersionList.java
@@ -19,6 +19,8 @@ public class VersionList {
     //Just copy pasted with a little resorting from Mojang's version manifest, https://launchermeta.mojang.com/mc/game/version_manifest.json
     //We can't read this file directly, because its in strict release date order, not target version order
     private final String[] versions = new String[] {
+        "26.3-snapshot-2",
+        "26.3-snapshot-1",
         "26.1-rc-2",
         "26.1-rc-1",
         "26.1-pre-3",


### PR DESCRIPTION
This pull request updates the handling and testing of Minecraft's new version numbering system, specifically for snapshot versions. The main changes include improving the parsing logic for snapshot versions and expanding the test coverage to include new snapshot version formats.

**Improvements to version parsing:**

* Updated the snapshot version parsing in `MinecraftVersion.java` to use `split("-snapshot-", 2)`, ensuring only the first occurrence is split and preventing issues with versions containing multiple `-snapshot-` substrings. Also, changed the default value for the `release` field from `null` to an empty string for consistency.

**Test coverage enhancements:**

* Added new snapshot versions (`26.3-snapshot-2`, `26.3-snapshot-1`) to the `versions` array in `VersionList.java` to ensure the new parsing logic is properly tested.